### PR TITLE
allow mismatch between the anayslis time and the time in the ensemble BEC files

### DIFF
--- a/src/mpasjedi/Fields/mpas_fields_mod.F90
+++ b/src/mpasjedi/Fields/mpas_fields_mod.F90
@@ -440,8 +440,13 @@ subroutine read_fields(self, f_conf, vdate)
    call MPAS_stream_mgr_set_property(self % manager, streamID, MPAS_STREAM_PROPERTY_FILENAME, filename)
    write(message,*) '--> read_fields: Reading ',trim(filename)
    call fckit_log%debug(message)
-   call MPAS_stream_mgr_read(self % manager, streamID=streamID, &
+   if (trim(streamID) == "ensemble") then
+      call MPAS_stream_mgr_read(self % manager, streamID=streamID, &
+                           & when=dateTimeString, rightNow=.True., whence=MPAS_STREAM_NEAREST, ierr=ierr)
+   else
+      call MPAS_stream_mgr_read(self % manager, streamID=streamID, &
                            & when=dateTimeString, rightNow=.True., ierr=ierr)
+   endif
    if ( ierr .ne. 0  ) then
       write(message,*) '--> read_fields: MPAS_stream_mgr_read failed ierr=',ierr
       call abor1_ftn(message)


### PR DESCRIPTION
### TYPE:
enhancement

### DESCRIPTION OF CHANGES:

RRFS.v2 has an option to use the GEFS/GDAS as the ensemble BEC in the hybrid 3DEnVAR process.
The GEFS/GDAS ensembles are interpolated to the target mesh (such as conus3km, conus12km, etc) using init_atmophere_model. We do this interpolation every 6 hours (00z, 06z, 12z, 18z). 

Each interpolated BECs will be used the following six cycles (i.e. hourly cycles). eg. 00z interpolated BECs will be used by the 00, 01, 02, 03, 04, 05 cycles.

Since 00z init.nc files contains 00z timestamp,  mpasjedi will crash at 01-05z cycles due to time mismatch.

This PR adds the `whence=MPAS_STREAM_NEAREST` parameter when calling `MPAS_stream_mgr_read` for the `ensemble` stream so that mpasjedi can continue to run and use the slightly-off-time ensemble BEC. 

This practice has been used for quite a long time in operation for multiple operational systems, such as RAP/HRRR, 3D-RTMA, RRFS, etc. 

### LIST OF MODIFIED FILES: 
`src/mpasjedi/Fields/mpas_fields_mod.F90`