### PR TITLE
Graphics Maintenance - compatible with latest npl

### DIFF
--- a/graphics/AnalyzeStats.py
+++ b/graphics/AnalyzeStats.py
@@ -12,6 +12,7 @@ import logging
 import logsetup
 import multiprocessing as mp
 import os
+import pandas as pd
 
 from analysis.Analyses import Analyses
 import analysis.StatisticsDatabase as sdb
@@ -66,12 +67,8 @@ def main():
       # where each pair is colon delimited, e.g. exp1:long_name_exp1,exp2:long_name_exp2
       exps = args.experiments.split(',')
 
-    firstCycle = None
-    lastCycle = None
-    if args.firstCycle:
-      firstCycle= dt.datetime.strptime(args.firstCycle, '%Y%m%dT%H')
-    if args.lastCycle:
-      lastCycle= dt.datetime.strptime(args.lastCycle, '%Y%m%dT%H')
+    firstCycle = pd.to_datetime(args.firstCycle)
+    lastCycle = pd.to_datetime(args.lastCycle)
 
     anconf.adjust_experiments(args.controlExperiment, exps, args.verifySpace, args.verifyType, firstCycle, lastCycle)
 

--- a/graphics/analysis/AnalysisBase.py
+++ b/graphics/analysis/AnalysisBase.py
@@ -238,22 +238,26 @@ class AnalysisBase():
         dmax = np.nanmax(d)
       return dmin, dmax
 
+
     def oneHundredCenteredLimiter(self, dmin0=np.NaN, dmax0=np.NaN, d=None):
-      dmin, dmax = self.initLimits(dmin0, dmax0, d)
+        dmin, dmax = self.initLimits(dmin0, dmax0, d)
 
-      # update dmax, conditional on dmin
-      dmax = np.nanmax([dmax, 100.0/(dmin/100.0)])
+        # Clamp dmin to its "Safety Envelope" (66.7% to 98.0%)
+        # This prevents division by zero and keeps the plot from being too squashed or too wide.
+        dmin = np.nanmax([dmin, 66.7])
+        dmin = np.nanmin([dmin, 98.0])
 
-      # set absolute min/max in case there are large outliers
-      #if np.isfinite(dmin):
-      dmin = np.nanmax([dmin, 66.7])
-      dmin = np.nanmin([dmin, 98.0])
+        # Clamp dmax to its "Safety Envelope" (102.0% to 150.0%)
+        dmax = np.nanmax([dmax, 102.0])
+        dmax = np.nanmin([dmax, 150.0])
 
-      #if np.isfinite(dmax):
-      dmax = np.nanmin([dmax, 150.0])
-      dmax = np.nanmax([dmax, 102.0])
+        # Symmetry Check
+        # Since dmin is at least 66.7, 100/(66.7/100) is ~150.
+        # This will never exceed our 150.0 ceiling.
+        dmax = np.nanmax([dmax, 100.0 / (dmin / 100.0)])
 
-      return dmin, dmax
+        return dmin, dmax
+
 
     def zeroCenteredPercentDifference(self,
       experiment,
@@ -291,23 +295,24 @@ class AnalysisBase():
       #return '100 x (EXP-'+self.cntrlExpName+') / \n'+self.cntrlExpName+''
       #return '100 x (EXP-CONTROL)/\nCONTROL'
 
+
     def zeroCenteredLimiter(self, dmin0=np.NaN, dmax0=np.NaN, d=None):
-      dmin, dmax = self.initLimits(dmin0, dmax0, d)
+        dmin, dmax = self.initLimits(dmin0, dmax0, d)
 
-      # update dmax, conditional on dmin
-      #dmax = np.nanmax([dmax, 100.0/((100.0+dmin)/100.0) - 100.0])
-      dmax = np.nanmax([dmax, 1.0/dmin])
+        # Ensures we always see at least -2.0 to +2.0
+        dmin = np.nanmin([dmin, -2.0])
+        dmax = np.nanmax([dmax, 2.0])
 
-      # set absolute min/max in case there are large outliers
-      #if np.isfinite(dmin):
-      dmin = np.nanmax([dmin, -33.3])
-      dmin = np.nanmin([dmin, -2.0])
+        # Prevents one bad observation from squishing the whole plot
+        dmin = np.nanmax([dmin, -33.3])
+        dmax = np.nanmin([dmax, 50.0])
 
-      #if np.isfinite(dmax):
-      dmax = np.nanmin([dmax, 50.0])
-      dmax = np.nanmax([dmax, 2.0])
+        # Symmetry (Optional/Legacy logic)
+        # With dmin clamped to -2.0, this maxes at 0.5.
+        # It won't override the 2.0 floor, but it's safe to keep.
+        dmax = np.nanmax([dmax, 1.0 / np.abs(dmin)])
 
-      return dmin, dmax
+        return dmin, dmax
 
 
     def binMethodFile(self, binMethod, before = True):

--- a/graphics/analysis/AnalysisBase.py
+++ b/graphics/analysis/AnalysisBase.py
@@ -10,7 +10,6 @@ import diag_utils as du
 import logging
 import numpy as np
 from pathlib import Path
-import plot_utils as pu
 import os
 import var_utils as vu
 import modelsp_utils as mu
@@ -357,7 +356,7 @@ class AnalysisBase():
         truncateDiagnostics = ommDiagnostics+mmoDiagnostics
         diagnosticGroup_ = diagnosticGroup
         #for diag in truncateDiagnostics:
-        #    if pu.prepends(diag, diagnosticGroup_) or pu.postpends(diag, diagnosticGroup_):
+        #    if diagnosticGroup_.startswith(diag) or diagnosticGroup_.endswith(diag):
         #        diagnosticGroup_ = diag
 
         allDiagnosticNames_ = deepcopy(allDiagnosticNames)
@@ -395,10 +394,10 @@ class AnalysisBase():
         centralValue = None
 
         #for diag in truncateDiagnostics:
-        #    if pu.prepends(diag, cntrlDiagnosticName) or pu.postpends(diag, cntrlDiagnosticName):
+        #    if cntrlDiagnosticName.startswith(diag) or cntrlDiagnosticName.endswith(diag):
         #        cntrlDiagnosticName = diag
         #    for idiag, adiag in enumerate(allDiagnosticNames_):
-        #        if pu.prepends(diag, adiag) or pu.postpends(diag, adiag):
+        #        if adiag.startswith(diag) or adiag.endswith(diag):
         #            allDiagnosticNames_[idiag] = diag
 
         oneCenteredRatioDiagPrefixes = ['CRx', 'CRy', 'InnovationRatio', 'SRx', 'SRy', 'OENI']
@@ -406,7 +405,7 @@ class AnalysisBase():
         for diag in allDiagnosticNames_:
             oneCentered = False
             for diagPrefix in oneCenteredRatioDiagPrefixes:
-                oneCentered = oneCentered or pu.prepends(diagPrefix, diag)
+                oneCentered = oneCentered or diag.startswith(diagPrefix)
             allOneCenteredDiagnostics = allOneCenteredDiagnostics and oneCentered
         if allOneCenteredDiagnostics:
             centralValue = 1.
@@ -419,7 +418,7 @@ class AnalysisBase():
         # for diag in allDiagnosticNames_:
         #     logScaled = False
         #     for diagPrefix in logScaledDiagPrefixes:
-        #         logScaled = logScaled or pu.prepends(diagPrefix, diag)
+        #         logScaled = logScaled or diag.startswith(diagPrefix)
         #     allLogScaledDiagnostics = allLogScaledDiagnostics and logScaled
         # if allLogScaledDiagnostics:
         #     logScale = True and not isDifferencePlot

--- a/graphics/analysis/BinValAxisStatsComposite.py
+++ b/graphics/analysis/BinValAxisStatsComposite.py
@@ -132,9 +132,9 @@ class BinValAxisStatsComposite(AnalysisBase):
                           varMapLoc.append((varName, varLabel))
 
                 nsubplots = nVarsLoc
-                nxplots = np.int(np.ceil(np.sqrt(nsubplots)))
+                nxplots = int(np.ceil(np.sqrt(nsubplots)))
                 while nsubplots%nxplots > 0 and nsubplots%nxplots / nxplots <= 0.5: nxplots += 1
-                nyplots = np.int(np.ceil(np.true_divide(nsubplots, nxplots)))
+                nyplots = int(np.ceil(np.true_divide(nsubplots, nxplots)))
 
                 ptLoc = {}
 

--- a/graphics/analysis/StatisticsDatabase.py
+++ b/graphics/analysis/StatisticsDatabase.py
@@ -26,7 +26,7 @@ class MultipleBinnedStatistics():
         for attribName in su.fileStatAttributes:
             self.values[attribName] = np.empty(nrows, np.chararray)
         for statName in su.allFileStats:
-            self.values[statName] = np.empty(nrows, np.float)
+            self.values[statName] = np.empty(nrows, float)
 
     @classmethod
     def read(cls, statsFile, expName, fcTDelta, cyDTime):

--- a/graphics/analysis/StatisticsDatabase.py
+++ b/graphics/analysis/StatisticsDatabase.py
@@ -402,94 +402,79 @@ class DFWrapper:
         return self.df.to_string()
 
     @classmethod
-    def fromLoc(cls, other, locDict, var=None):
-        return cls(other.locdf(other.locTuple(locDict), var))
-
-    @classmethod
     def fromAggStats(cls, other, aggovers):
         return cls(other.aggStats(aggovers))
 
     def append(self, otherDF = None):
-        if otherDF is None: return
+        if otherDF is None or otherDF.empty:
+            return
+        self.df = pd.concat([self.df, otherDF], sort=True)
 
-        #Add otherDF (DataFrame object) to self.df
-        # adds new column names as needed
-        # adds meaningless NaN entries in columns that do not overlap between two DF's
-        # TODO: reduce memory footprint of NaN's via modifications to external data flows
-        appendDF = otherDF.copy(True)
-
-        selfColumns = list(self.df.columns)
-        appendColumns = list(appendDF.columns)
-
-        selfNRows = len(self.df.index)
-        for column in appendColumns:
-            if column not in selfColumns:
-                self.df.insert(len(list(self.df.columns)), column, [np.NaN]*selfNRows)
-
-        appendNRows = len(appendDF.index)
-        for column in selfColumns:
-            if column not in appendColumns:
-                appendDF.insert(len(list(appendDF.columns)), column, [np.NaN]*appendNRows)
-
-        self.df = self.df.append(appendDF, sort=True)
-
-    def locTuple(self, locDict={}):
-        Loc = ()
-        for index in list(locDict.keys()):
-            assert index in self.indexNames,(
-                "\n\nERROR: index name not in the multiindex, index = "+index
-                +", indexNames = ", self.indexNames)
-
-        for index in self.indexNames:
-            indL = list(Loc)
-            if index not in locDict:
-                indL.append(slice(None))
-            elif locDict[index] is None:
-                indL.append(slice(None))
-            elif (isinstance(locDict[index], Iterable) and
-                not isinstance(locDict[index], str)):
-                indL.append(list(locDict[index]))
-            else:
-                indL.append(list([locDict[index]]))
-            Loc = tuple(indL)
-        return Loc
-
-    def locdf(self, Loc, var=None):
-        if var is None:
-            return self.df.loc[Loc, :]
-        else:
-            return self.df.loc[Loc, var]
-
-    def levels(self, index, locDict={}):
-        newDF = self.locdf(self.locTuple(locDict))
-        return dfIndexLevels(newDF, index)
+    @classmethod
+    def fromLoc(cls, other, locDict, var=None):
+        return cls(other.loc(locDict, var))
 
     def loc(self, locDict, var=None):
-        return self.locdf(self.locTuple(locDict), var)
+        # 1. Start with a boolean mask where everything is True
+        mask = np.ones(len(self.df), dtype=bool)
+
+        # 2. Filter down level by level natively
+        for level_name, val in locDict.items():
+            if val is None:
+                continue
+
+            # Get the actual data for this index level
+            level_vals = self.df.index.get_level_values(level_name)
+
+            # If the filter is a list of items, use native .isin()
+            if isinstance(val, (list, tuple, set, np.ndarray)):
+                mask = mask & level_vals.isin(val)
+
+            # If it is a single value, use standard equality
+            else:
+                level_mask = (level_vals == val)
+
+                # If no match is found, and we searched for a string (like '-0.25'),
+                # check if Pandas stored it as a float in the index.
+                if not level_mask.any() and isinstance(val, str):
+                    try:
+                        level_mask = (level_vals == float(val))
+                    except ValueError:
+                        pass # It was a real string, not a number
+
+                mask = mask & level_mask
+
+        # 3. Apply the mask
+        filtered_df = self.df.loc[mask]
+
+        # 4. Return specific column(s) if requested
+        if var is not None:
+            return filtered_df[var]
+
+        return filtered_df
+
+    def levels(self, index, locDict={}):
+        newDF = self.loc(locDict)
+        return dfIndexLevels(newDF, index)
 
     def loc1(self, locDict, var=None):
-        s = self.loc(locDict, var).to_numpy()
-        if isinstance(s, Iterable):
-          if len(s) == 1:
-            return s[0]
-          else:
+        res = self.loc(locDict, var)
+        # if result is empty or has multiple values, return NaN
+        if len(res) != 1:
             return np.NaN
-          #assert len(s) == 1, "DFWrapper::loc0, locDict/var must return single location only"
-          #return s[0]
-        else:
-          return s
+        return res.item()
 
     def var(self, var):
-        return self.loc({}, var=var)
+        return self.df[var]
 
     def uniquevals(self, var, locDict={}):
-        return pu.uniqueMembers(self.loc(locDict, var).tolist())
+        return self.loc(locDict, var).dropna().unique().tolist()
 
     def min(self, locDict, var=None):
-       return self.loc(locDict, var).dropna().min()
+       return self.loc(locDict, var).min()
 
     def max(self, locDict, var):
-        return self.loc(locDict, var).dropna().max()
+        return self.loc(locDict, var).max()
 
     def aggStats(self, aggovers):
         groupby = deepcopy(self.indexNames)

--- a/graphics/analysis/StatisticsDatabase.py
+++ b/graphics/analysis/StatisticsDatabase.py
@@ -56,27 +56,24 @@ class MultipleBinnedStatistics():
         return new
 
     def insert(self, other, srow):
-        assert srow >= 0, ("Error: can only insert MultipleBinnedStatistics rows >= 0, not ", srow)
+        assert srow >= 0, f"Error: can only insert MultipleBinnedStatistics rows >= 0, not {srow}"
         erow = srow + other.nrows - 1
-        assert erow < self.nrows, ("Error: can only insert MultipleBinnedStatistics rows < ", self.nrows, ", not ", erow)
+        assert erow < self.nrows, f"Error: can only insert MultipleBinnedStatistics rows < {self.nrows}, not {erow}"
+
         for key, val in other.values.items():
-            if isinstance(val, Iterable):
-                assert key in self.values, key+" not in MultipleBinnedStatistics"
-                self.values[key][srow:erow+1] = val[:]
+            assert key in self.values, f"{key} not in MultipleBinnedStatistics"
+            self.values[key][srow:erow+1] = val
 
     def destroy(self):
         del self.values
 
 
-def dfIndexLevels(df, index):
-    mi = df.index.names
-    return pu.uniqueMembers(
-               df.index.get_level_values(
-                   mi.index(index) ).tolist() )
+def dfIndexLevels(df, index_name):
+    return df.index.get_level_values(index_name).unique().tolist()
 
 
 def dfVarVals(df, loc, var):
-    return pu.uniqueMembers(df.loc[loc, var].tolist())
+    return df.loc[loc, var].unique().tolist()
 
 
 class StatsDB:
@@ -487,42 +484,28 @@ class DFWrapper:
 
 
 def TDelta_dir(tdelta, fmt):
-    subs = {}
-    fmts = {}
-    i = '{:d}'
-    i02 = '{:02d}'
+    """Formats a timedelta into a directory string using a replacement map."""
+    # Pre-calculate all necessary values
+    total_seconds = int(tdelta.total_seconds())
+    h_rem, rem = divmod(tdelta.seconds, 3600)
+    m_rem, s_rem = divmod(rem, 60)
 
-    # "%D %HH:%MM:%SS"
-    subs["D"] = tdelta.days
-    fmts["D"] = i
+    # Define the mapping (Key: Formatted Value)
+    subs = {
+        "%D":   str(tdelta.days),
+        "%HH":  f"{h_rem:02d}",
+        "%MM":  f"{m_rem:02d}",
+        "%SS":  f"{s_rem:02d}",
+        "%h":   str(total_seconds // 3600),
+        "%MIN": str(total_seconds // 60),
+        "%SEC": f"{s_rem:02d}",
+        "%m":   str(total_seconds // 60),
+        "%s":   str(total_seconds)
+    }
 
-    subs["HH"], hrem = divmod(tdelta.seconds, 3600)
-    fmts["HH"] = i02
+    # Direct replacement loop
+    for key, val in subs.items():
+        if key in fmt:
+            fmt = fmt.replace(key, val)
 
-    subs["MM"], subs["SS"] = divmod(hrem, 60)
-    fmts["MM"] = i02
-    fmts["SS"] = i02
-
-    ts = int(tdelta.total_seconds())
-
-    # "%h"
-    subs["h"], hrem = divmod(ts, 3600)
-    fmts["h"] = i
-
-    # "%MIN:%SEC"
-    subs["MIN"], subs["SEC"] = divmod(ts, 60)
-    fmts["MIN"] = i
-    fmts["SEC"] = i02
-
-    subs["m"] = subs["MIN"]
-    fmts["m"] = fmts["MIN"]
-
-    # "%s"
-    subs["s"] = ts
-    fmts["s"] = i
-
-    out = fmt
-    for key in subs.keys():
-        out = out.replace("%"+key, fmts[key].format(subs[key]))
-
-    return out
+    return fmt

--- a/graphics/analysis/category/CategoryBinMethodBase.py
+++ b/graphics/analysis/category/CategoryBinMethodBase.py
@@ -54,9 +54,9 @@ class CategoryBinMethodBase(AnalysisBase):
             nsubplots = nxplots * nyplots
         else:
             nsubplots = self.nVars
-            nxplots = np.int(np.ceil(np.sqrt(nsubplots)))
+            nxplots = int(np.ceil(np.sqrt(nsubplots)))
             while nsubplots%nxplots > 0 and nsubplots%nxplots / nxplots <= 0.5: nxplots += 1
-            nyplots = np.int(np.ceil(np.true_divide(nsubplots, nxplots)))
+            nyplots = int(np.ceil(np.true_divide(nsubplots, nxplots)))
 
         return nxplots, nyplots, nsubplots
 

--- a/graphics/analysis/category/FCScoreCard.py
+++ b/graphics/analysis/category/FCScoreCard.py
@@ -356,9 +356,9 @@ class FCScoreCard(CategoryBinMethodBase):
             nsubplots = nxplots * nyplots
         else:
             nsubplots = nSubplotsPerExp
-            nxplots = np.int(np.ceil(np.sqrt(nsubplots)))
+            nxplots = int(np.ceil(np.sqrt(nsubplots)))
             while nsubplots%nxplots > 0 and nsubplots%nxplots / nxplots <= 0.5: nxplots += 1
-            nyplots = np.int(np.ceil(np.true_divide(nsubplots, nxplots)))
+            nyplots = int(np.ceil(np.true_divide(nsubplots, nxplots)))
 
         xVals = self.fcTDeltas
 

--- a/graphics/analysis/multidim/BinValAxes2D.py
+++ b/graphics/analysis/multidim/BinValAxes2D.py
@@ -167,14 +167,14 @@ class BinValAxes2D(MultiDimBinMethodBase):
 
         # determine the coordinates of the structued X/Y grid points
         xUnique = np.array(pu.uniqueMembers(xCoords))
-        xVals = np.asarray(xUnique, dtype=np.float)
+        xVals = np.asarray(xUnique, dtype=float)
         xSort = np.argsort(xVals)
         xVals = xVals[xSort]
         nXVals = len(xVals)
         xValsStr = list(xUnique[xSort])
 
         yUnique = np.array(pu.uniqueMembers(yCoords))
-        yVals = np.asarray(yUnique, dtype=np.float)
+        yVals = np.asarray(yUnique, dtype=float)
         ySort = np.argsort(yVals)
         yVals = yVals[ySort]
         nYVals = len(yVals)

--- a/graphics/analysis/multidim/BinValAxes2D.py
+++ b/graphics/analysis/multidim/BinValAxes2D.py
@@ -368,11 +368,15 @@ class BinValAxes2D(MultiDimBinMethodBase):
                                 t = float(ciVals[statName][trait])
                                 # automatically generate relative difference plots for positive-semi-definite statistics
                                 if useRelativeDifference:
-                                  # divide by cntrlLoc aggregated statName
-                                  t /= normalizingStat
-                                  if self.relativeErrorType == 'one hundred centered':
-                                    t += 1.0
-                                  t *= 100.0
+                                    if normalizingStat != 0 and np.isfinite(normalizingStat):
+                                        # divide by cntrlLoc aggregated statName
+                                        t /= normalizingStat
+                                        if self.relativeErrorType == 'one hundred centered':
+                                            t += 1.0
+                                        t *= 100.0
+                                    else:
+                                        t = np.NaN
+
                                 planeVals[trait][iy, ix] = t
 
                         # automatically generate relative difference plots for positive-semi-definite statistics

--- a/graphics/analysis/multidim/BinValAxisProfile.py
+++ b/graphics/analysis/multidim/BinValAxisProfile.py
@@ -49,9 +49,9 @@ class BinValAxisProfile(MultiDimBinMethodBase):
             nsubplots = nxplots * nyplots
         else:
             nsubplots = np.nanmax([nVarsLoc, 1])
-            nxplots = np.nanmax([np.int(np.ceil(np.sqrt(nsubplots))), 1])
+            nxplots = np.nanmax([int(np.ceil(np.sqrt(nsubplots))), 1])
             while nsubplots%nxplots > 0 and nsubplots%nxplots / nxplots <= 0.5: nxplots += 1
-            nyplots = np.int(np.ceil(np.true_divide(nsubplots, nxplots)))
+            nyplots = int(np.ceil(np.true_divide(nsubplots, nxplots)))
 
         ptLoc = {}
         axisLimitsLoc = {}
@@ -225,9 +225,9 @@ class BinValAxisProfileDiffCI(MultiDimBinMethodBase):
             nsubplots = nxplots * nyplots
         else:
             nsubplots = np.nanmax([nVarsLoc, 1])
-            nxplots = np.nanmax([np.int(np.ceil(np.sqrt(nsubplots))), 1])
+            nxplots = np.nanmax([int(np.ceil(np.sqrt(nsubplots))), 1])
             while nsubplots%nxplots > 0 and nsubplots%nxplots / nxplots <= 0.5: nxplots += 1
-            nyplots = np.int(np.ceil(np.true_divide(nsubplots, nxplots)))
+            nyplots = int(np.ceil(np.true_divide(nsubplots, nxplots)))
 
         # Only bootstrap over the union of cyDTimes available
         # from both experiments at each fcTDelta

--- a/graphics/analyze_config.py
+++ b/graphics/analyze_config.py
@@ -96,6 +96,10 @@ def adjust_experiments(control, expArray, verifySpace, verifyType, firstCycle, l
   if verifyType:
     VerificationType = verifyType
     verificationChanged = True
+  if firstCycle and lastCycle and firstCycle > lastCycle:
+      raise ValueError(f"firstCycle ({firstCycle}) > lastCycle ({lastCycle})")
+  if firstCycle and lastCycle is None:
+      raise ValueError(f"if firstCycle is set, lastCycle must be set (-l option)")
   if firstCycle:
     dbConf['firstCycleDTime'] = firstCycle
   if lastCycle:
@@ -305,8 +309,7 @@ else:
 ## expDirectory is the top-level directory that contains data
 #  from all experiments.  The environment variable, EXP_DIR, can be used
 #  to specify its value externally if desired.
-user = os.environ['USER']
-dbConf['expDirectory'] = os.getenv('EXP_DIR','/glade/derecho/scratch/'+user+'/pandac')
+dbConf['expDirectory'] = os.getenv('EXP_DIR', os.path.join(os.getenv('SCRATCH'), 'pandac'))
 
 ## hasFCLenDir whether directory structure includes forecast length
 #  overridden to True within StatisticsDatabase.StatsDB when fcTDeltaLast > fcTDeltaFirst

--- a/graphics/basic_plot_functions.py
+++ b/graphics/basic_plot_functions.py
@@ -1393,7 +1393,7 @@ def plotTimeSeries(fig,
     if nLines <= maxLegendEntries:
         if legend_inside:
             #INSIDE AXES
-            nlcol = np.int(np.ceil(np.sqrt(nLines)))
+            nlcol = int(np.ceil(np.sqrt(nLines)))
             lh = ax.legend(loc='best',fontsize=legendLabelFontSize1,frameon=True,
                            framealpha=0.4,ncol=nlcol)
             lh.get_frame().set_linewidth(0.0)

--- a/graphics/standalone/plot_diag.py
+++ b/graphics/standalone/plot_diag.py
@@ -389,6 +389,11 @@ def readdata(args: argparse.Namespace) -> None:
         for varGrp in readVars:
           if varGrp is None: continue
           var, grp = vu.splitObsVarGrp(varGrp)
+
+          if grp not in ncDB.groups:
+              print(f'WARNING: group {grp} not in {file}')
+              continue
+
           # recordNumber is not available in ctest data files
           # In that case, assume record and station counts are identical
           if (varGrp == record and

--- a/graphics/standalone/plot_diag.py
+++ b/graphics/standalone/plot_diag.py
@@ -1,5 +1,6 @@
 import argparse
 import glob
+import logging
 import math
 import os
 import re
@@ -204,7 +205,7 @@ def readdata(args: argparse.Namespace) -> None:
   # collect all file names that fit file name format
   obsoutfiles = list(diagdir.glob(f'{diagprefix}*{diagsuffix}'))
   if not obsoutfiles:
-      print(f"No obsout files matching '{diagprefix}*{diagsuffix}'")
+      logging.warning(f"No obsout files matching '{diagprefix}*{diagsuffix}'")
 
   # Group files by experiment-obstype combination
   #  (e.g., 3dvar_aircraft), where each group
@@ -229,14 +230,14 @@ def readdata(args: argparse.Namespace) -> None:
   # Loop over experiment-obstype groups
   for expt_obs, files in exob_groups.items():
     if "_" not in expt_obs:
-      print(f"no obstype in {expt_obs}. skip.")
+      logging.warning(f"no obstype in {expt_obs}. skip.")
       continue
 
     # obstype is everything after first underscore
     obstype = expt_obs.split("_", 1)[1]
     # If obstype string is not found in one of the analyzedObsTypes...
     if not any(obstype in analyzedObsType for analyzedObsType in analyzedObsTypes):
-      print(f'{obstype} not in one of analyzedObsTypes. skip.')
+      logging.warning(f'{obstype} not in one of analyzedObsTypes. skip.')
       continue
 
     print(f"Processing experiment_obstype {expt_obs}")
@@ -391,7 +392,7 @@ def readdata(args: argparse.Namespace) -> None:
           var, grp = vu.splitObsVarGrp(varGrp)
 
           if grp not in ncDB.groups:
-              print(f'WARNING: group {grp} not in {file}')
+              logging.warning(f'group {grp} not in {file}')
               continue
 
           # recordNumber is not available in ctest data files
@@ -432,7 +433,7 @@ def readdata(args: argparse.Namespace) -> None:
               if station is not None and stationID == station: station = None
               pass
             else:
-              print('Incorrect unicode format for '+varGrp+' in '+file)
+              logging.error('Incorrect unicode format for '+varGrp+' in '+file)
               raise UnicodeDecodeError(p)
 
         ss = ee
@@ -492,7 +493,7 @@ def readdata(args: argparse.Namespace) -> None:
         db[var][~passan] = np.NaN
 
       if not np.isfinite(db[omb]).any():
-        print('all values are NaN or inf: ', varName, obstype)
+        logging.warning('all values are NaN or inf: ', varName, obstype)
         continue
 
       # diagnose relative omb/oma for GNSSRO, which varies
@@ -935,7 +936,7 @@ def scatter_verification(ifig, varName, varUnits, ivar, nvars,
       xlab = 'h(xb) - y'
       ylab = 'h(xa) - y'
     else:
-      print('WARNING: scatter_verification has no definitions for nfigtypes == ', nfigtypes)
+      logging.warning('scatter_verification has no definitions for nfigtypes == ', nfigtypes)
       continue
 
     # Uncomment these 2 lines to put x/y labels only on peripheral subplts
@@ -1007,18 +1008,18 @@ def scatter_one2ones(XVAL, YVALS, LEG, show_stats, XLAB, YLAB, VAR_NAME, UNITS, 
           ha='left', va='top', transform=ax.transAxes)
 
   if len(XVAL) == 0:
-    print('WARNING in scatter_one2ones: len(XVAL)==0; skipping this dataset')
+    logging.warning('in scatter_one2ones: len(XVAL)==0; skipping this dataset')
     return 1
   NVALS = np.asarray([])
   for i, YVAL in enumerate(YVALS):
     if len(XVAL) != len(YVAL):
-      print('ERROR: Incorrect usage of scatter_one2ones, YVALS must be list of arrays.')
+      logging.error('Incorrect usage of scatter_one2ones, YVALS must be list of arrays.')
       os._exit()
     not_nan = np.isfinite(XVAL) & np.isfinite(YVAL)
     NVALS = np.append(NVALS, np.sum(not_nan))
 
   if np.all(NVALS == 0):
-    print('WARNING in scatter_one2ones: all(XVAL/YVAL) are non-finite; skipping this dataset')
+    logging.warning('in scatter_one2ones: all(XVAL/YVAL) are non-finite; skipping this dataset')
     return 1
 
   colors = [

--- a/graphics/standalone/plot_diag.py
+++ b/graphics/standalone/plot_diag.py
@@ -86,7 +86,7 @@ def readdata(args: argparse.Namespace) -> None:
   makeDistributionPlots = True
   plot_allinOneDistri = True   # plot profileObsTypes (includes all levels) and sfcObsTypes.
   plot_eachLevelDistri = False # plot every level separately for profileObsTypes.
-  plot_predictorDistri = False  # Default is False; should turn on it with makeDistributionPlots = True
+  plot_predictorDistri = args.predictors
 
   # NOUTER: number of outer iterations
   # can be set as env variable 'NOUTER'
@@ -711,11 +711,17 @@ def readdata(args: argparse.Namespace) -> None:
             basic_plot_functions.plotDistri(db[latitude], db[longitude], db[ana][:,ich],
                                         obstype, shortname, units, expt_obs, 0, "ana", **kwargs)
             if plot_predictorDistri:
-              print('plotting predictors distribution for : '+obstype+ 'ch'+str(channel))
-              for ipred, pred in enumerate(predVars):
-                basic_plot_functions.plotDistri(db[latitude], db[longitude], db[pred][:,ich],
-                                        obstype, predGroup[ipred], "ch"+str(channel),
-                                        expt_obs, 0, "ch"+str(channel), **kwargs)
+                print(f'plot {len(predVars)} predictors for {obstype} ch{channel}')
+                kwargs_copy = kwargs.copy()
+                # predictors don't have same range of values as obsType. Let matplotlib pick vmin, vmax.
+                del(kwargs_copy['vmin'])
+                del(kwargs_copy['vmax'])
+                for ipred, pred in enumerate(predVars):
+                    basic_plot_functions.plotDistri(
+                        db[latitude], db[longitude], db[pred][:,ich],
+                        obstype, predGroup[ipred], "ch"+str(channel),
+                        expt_obs, 0, "ch"+str(channel), **kwargs_copy
+                    )
             goodrange = np.nanpercentile(np.abs(np.concatenate((db[omb][:,ich], db[oma][:,ich]))), 98)
             kwargs.update({"cmap": plt.colormaps["RdBu_r"]})
             kwargs.update({"vmin": -goodrange})
@@ -1116,6 +1122,7 @@ def main():
         help="Path to optional YAML config file for plot styling",
     )
     parser.add_argument("--diagdir", help="Path to data", default="../..")
+    parser.add_argument("--predictors", action='store_true', help="plot predictors")
     args = parser.parse_args()
 
     readdata(args)


### PR DESCRIPTION
**TYPE:** maintenance

**DESCRIPTION OF CHANGES:**
This PR provides a comprehensive update to the MPAS-JEDI graphics suite. Key improvements focus on code simplicity, robustness, and compatibility with lastest Python conda environment (`npl-2025b`).

### 1. Modernization
* **Pandas Integration:** Migrated `datetime` parsing in `AnalyzeStats.py` to `pd.to_datetime` for more flexible input handling.
* **Vectorized Data Extraction:** Rewrote `DFWrapper` and associated helper functions (`dfIndexLevels`, `uniquevals`) to use native Pandas `.unique()`, `.isin()`, and boolean masking. This eliminates slow Python loops and drastically reduces memory overhead for large datasets.
* **NumPy Compatibility:** Replaced deprecated `np.int` and `np.float` with native `int` and `float` types to support NumPy 1.24+ and prevent future deprecation errors.

### 2. Warning Elimination (Limits & Normalization)
* **Zero-Centered Limiter Logic:** Reordered the logic in `oneHundredCenteredLimiter` and `zeroCenteredLimiter` to apply safety clamps before performing division. This silences `RuntimeWarning: divide by zero encountered in scalar divide` which occurred when `dmin` was initially 0. 



* **Safe Normalization:** Fixed `BinValAxes2D.py` to explicitly check if `normalizingStat` is non-zero and finite before calculating relative differences. Gaps in control data now correctly result in `NaN` rather than `inf` or runtime warnings.

### 3. Dependency and Code Cleanup
* **`plot_utils` Decoupling:** Severed dependencies on `plot_utils` in several core modules. Replaced `pu.prepends` and `pu.postpends` with native Python `.startswith()` and `.endswith()`.
* **String Parsing:** Refactored `TDelta_dir` into a cleaner dictionary-based replacement loop.
* **Path Resilience:** Updated `analyze_config.py` to use `os.path.join` and generic environment variables (`$SCRATCH`) instead of hardcoded user paths.

**Note:** This PR removes the requirement for the `npl-2023a` conda environment; the suite now runs on `npl-2025b`. No more divide by zero or invalid value warnings. Code is shorter but preserves legacy functionality.

**ISSUE:**
N/A

**LIST OF MODIFIED FILES:**
* `graphics/AnalyzeStats.py`
* `graphics/analysis/AnalysisBase.py`
* `graphics/analysis/BinValAxisStatsComposite.py`
* `graphics/analysis/StatisticsDatabase.py`
* `graphics/analysis/category/CategoryBinMethodBase.py`
* `graphics/analysis/category/FCScoreCard.py`
* `graphics/analysis/multidim/BinValAxes2D.py`
* `graphics/analysis/multidim/BinValAxisProfile.py`
* `graphics/analyze_config.py`
* `graphics/basic_plot_functions.py`
* `graphics/standalone/plot_diag.py`

**TESTS CONDUCTED:**
* Conducted side-by-side comparison of generated plots; all output remains identical to legacy code.
* Verified that logs are now silent regarding "Divide by zero" and "Invalid value" warnings during standard workflows.
* Verified execution in the latest NPL environment without legacy environment activation.